### PR TITLE
Disable password reset for non-Hostari emails

### DIFF
--- a/app/Services/Users/UserCreationService.php
+++ b/app/Services/Users/UserCreationService.php
@@ -51,7 +51,7 @@ class UserCreationService
         }
 
         $this->connection->commit();
-        if (!str_ends_with($user->email, '@hostari.com')) {
+        if (str_ends_with($user->email, '@hostari.com')) {
             $user->notify(new AccountCreated($user, $token ?? null));
         }
 

--- a/app/Services/Users/UserCreationService.php
+++ b/app/Services/Users/UserCreationService.php
@@ -51,7 +51,9 @@ class UserCreationService
         }
 
         $this->connection->commit();
-        $user->notify(new AccountCreated($user, $token ?? null));
+        if (!str_ends_with($user->email, '@hostari.com')) {
+            $user->notify(new AccountCreated($user, $token ?? null));
+        }
 
         return $user;
     }


### PR DESCRIPTION
Pterodactyl Panel shall not send a password reset email to any email created via API that does not start with @hostari.com

Only send password reset emails to accounts that start with @hostari.com when created via API