### PR TITLE
Add an idempotent egg sync API

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -13,7 +13,7 @@ on:
 jobs:
   ui:
     name: UI
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,7 +13,7 @@ on:
 jobs:
   tests:
     name: Tests
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -16,7 +16,7 @@ on:
 jobs:
   push:
     name: Push
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     if: "!contains(github.ref, 'develop') || (!contains(github.event.head_commit.message, 'skip docker') && !contains(github.event.head_commit.message, 'docker skip'))"
     steps:
       - name: Code checkout

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -17,7 +17,7 @@ jobs:
   push:
     name: Push
     runs-on: ubuntu-22.04
-    if: "!contains(github.ref, 'develop') || (!contains(github.event.head_commit.message, 'skip docker') && !contains(github.event.head_commit.message, 'docker skip'))"
+    if: "github.event_name != 'pull_request' && (!contains(github.ref, 'develop') || (!contains(github.event.head_commit.message, 'skip docker') && !contains(github.event.head_commit.message, 'docker skip')))"
     steps:
       - name: Code checkout
         uses: actions/checkout@v3

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -13,7 +13,7 @@ on:
 jobs:
   lint:
     name: Lint
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Code Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -8,7 +8,7 @@ on:
 jobs:
   release:
     name: Release
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Code checkout
         uses: actions/checkout@v3

--- a/app/Http/Controllers/Api/Application/Nests/EggController.php
+++ b/app/Http/Controllers/Api/Application/Nests/EggController.php
@@ -2,15 +2,28 @@
 
 namespace Pterodactyl\Http\Controllers\Api\Application\Nests;
 
+use Illuminate\Http\Response;
 use Pterodactyl\Models\Egg;
 use Pterodactyl\Models\Nest;
+use Illuminate\Http\JsonResponse;
+use Pterodactyl\Exceptions\Service\InvalidFileUploadException;
+use Pterodactyl\Services\Eggs\Sharing\EggImporterService;
 use Pterodactyl\Transformers\Api\Application\EggTransformer;
+use Pterodactyl\Services\Eggs\Sharing\EggUpdateImporterService;
 use Pterodactyl\Http\Requests\Api\Application\Nests\Eggs\GetEggRequest;
 use Pterodactyl\Http\Requests\Api\Application\Nests\Eggs\GetEggsRequest;
+use Pterodactyl\Http\Requests\Api\Application\Nests\Eggs\ImportEggRequest;
 use Pterodactyl\Http\Controllers\Api\Application\ApplicationApiController;
 
 class EggController extends ApplicationApiController
 {
+    public function __construct(
+        private EggImporterService $importerService,
+        private EggUpdateImporterService $updateImporterService
+    ) {
+        parent::__construct();
+    }
+
     /**
      * Return all eggs that exist for a given nest.
      */
@@ -26,8 +39,83 @@ class EggController extends ApplicationApiController
      */
     public function view(GetEggRequest $request, Nest $nest, Egg $egg): array
     {
+        $this->ensureEggBelongsToNest($nest, $egg);
+
         return $this->fractal->item($egg)
             ->transformWith($this->getTransformer(EggTransformer::class))
             ->toArray();
+    }
+
+    /**
+     * Import an egg document into the specified nest.
+     * A new import returns 201; an identical idempotent retry returns 200.
+     *
+     * @throws \Throwable
+     */
+    public function store(ImportEggRequest $request, Nest $nest): JsonResponse
+    {
+        try {
+            $result = $this->importerService->handleIdempotentDocument(
+                $request->document(),
+                $nest->id,
+                $request->idempotencyKey(),
+                $request->documentHash()
+            );
+        } catch (InvalidFileUploadException $exception) {
+            return $this->invalidDocumentResponse($exception);
+        }
+
+        if ($result['conflict']) {
+            return new JsonResponse([
+                'errors' => [[
+                    'code' => 'EggSyncConflict',
+                    'status' => (string) Response::HTTP_CONFLICT,
+                    'detail' => sprintf(
+                        'This idempotency key is already assigned to egg %d with a different payload. Update that egg by ID using PUT.',
+                        $result['egg']->id
+                    ),
+                    'meta' => ['egg_id' => $result['egg']->id],
+                ]],
+            ], Response::HTTP_CONFLICT);
+        }
+
+        return $this->fractal->item($result['egg'])
+            ->transformWith($this->getTransformer(EggTransformer::class))
+            ->respond($result['created'] ? Response::HTTP_CREATED : Response::HTTP_OK);
+    }
+
+    /**
+     * Replace an egg's imported configuration while retaining its identity.
+     *
+     * @throws \Throwable
+     */
+    public function update(ImportEggRequest $request, Nest $nest, Egg $egg): JsonResponse
+    {
+        $this->ensureEggBelongsToNest($nest, $egg);
+        try {
+            $egg = $this->updateImporterService->handleDocument($egg, $request->document(), $request->documentHash());
+        } catch (InvalidFileUploadException $exception) {
+            return $this->invalidDocumentResponse($exception);
+        }
+
+        return $this->fractal->item($egg)
+            ->transformWith($this->getTransformer(EggTransformer::class))
+            ->respond(Response::HTTP_OK);
+    }
+
+    private function ensureEggBelongsToNest(Nest $nest, Egg $egg): void
+    {
+        abort_unless($egg->nest_id === $nest->id, Response::HTTP_NOT_FOUND);
+    }
+
+    private function invalidDocumentResponse(InvalidFileUploadException $exception): JsonResponse
+    {
+        return new JsonResponse([
+            'errors' => [[
+                'code' => 'InvalidEggDocument',
+                'status' => (string) Response::HTTP_UNPROCESSABLE_ENTITY,
+                'detail' => $exception->getMessage(),
+            ]],
+        ], Response::HTTP_UNPROCESSABLE_ENTITY);
     }
 }

--- a/app/Http/Controllers/Api/Application/Nests/EggController.php
+++ b/app/Http/Controllers/Api/Application/Nests/EggController.php
@@ -2,18 +2,18 @@
 
 namespace Pterodactyl\Http\Controllers\Api\Application\Nests;
 
-use Illuminate\Http\Response;
 use Pterodactyl\Models\Egg;
 use Pterodactyl\Models\Nest;
+use Illuminate\Http\Response;
 use Illuminate\Http\JsonResponse;
-use Pterodactyl\Exceptions\Service\InvalidFileUploadException;
 use Pterodactyl\Services\Eggs\Sharing\EggImporterService;
 use Pterodactyl\Transformers\Api\Application\EggTransformer;
+use Pterodactyl\Exceptions\Service\InvalidFileUploadException;
 use Pterodactyl\Services\Eggs\Sharing\EggUpdateImporterService;
 use Pterodactyl\Http\Requests\Api\Application\Nests\Eggs\GetEggRequest;
 use Pterodactyl\Http\Requests\Api\Application\Nests\Eggs\GetEggsRequest;
-use Pterodactyl\Http\Requests\Api\Application\Nests\Eggs\ImportEggRequest;
 use Pterodactyl\Http\Controllers\Api\Application\ApplicationApiController;
+use Pterodactyl\Http\Requests\Api\Application\Nests\Eggs\ImportEggRequest;
 
 class EggController extends ApplicationApiController
 {

--- a/app/Http/Requests/Admin/Egg/EggScriptFormRequest.php
+++ b/app/Http/Requests/Admin/Egg/EggScriptFormRequest.php
@@ -14,8 +14,8 @@ class EggScriptFormRequest extends AdminFormRequest
         return [
             'script_install' => 'sometimes|nullable|string',
             'script_is_privileged' => 'sometimes|required|boolean',
-            'script_entry' => 'sometimes|required|string',
-            'script_container' => 'sometimes|required|string',
+            'script_entry' => 'sometimes|required|string|max:191',
+            'script_container' => 'sometimes|required|string|max:191',
             'copy_script_from' => 'sometimes|nullable|numeric',
         ];
     }

--- a/app/Http/Requests/Api/Application/Nests/Eggs/ImportEggRequest.php
+++ b/app/Http/Requests/Api/Application/Nests/Eggs/ImportEggRequest.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace Pterodactyl\Http\Requests\Api\Application\Nests\Eggs;
+
+use Illuminate\Validation\Rule;
+use Illuminate\Validation\Validator;
+use Pterodactyl\Services\Acl\Api\AdminAcl;
+use Pterodactyl\Services\Eggs\EggParserService;
+use Pterodactyl\Http\Requests\Api\Application\ApplicationApiRequest;
+
+class ImportEggRequest extends ApplicationApiRequest
+{
+    protected ?string $resource = AdminAcl::RESOURCE_EGGS;
+
+    protected int $permission = AdminAcl::WRITE;
+
+    protected function prepareForValidation(): void
+    {
+        if ($this->isMethod('post')) {
+            $this->merge(['idempotency_key' => $this->header('Idempotency-Key')]);
+        }
+    }
+
+    public function rules(): array
+    {
+        $rules = [
+            'meta' => ['required', 'array'],
+            'meta.version' => ['required', 'string', Rule::in(['PTDL_v1', 'PTDL_v2'])],
+        ];
+
+        if ($this->isMethod('post')) {
+            $rules['idempotency_key'] = [
+                'required',
+                'string',
+                'between:8,128',
+                'regex:/^[A-Za-z0-9][A-Za-z0-9._:-]*$/',
+            ];
+        }
+
+        return $rules;
+    }
+
+    public function withValidator(Validator $validator): void
+    {
+        $validator->after(function (Validator $validator) {
+            if (strlen($this->getContent()) > EggParserService::MAX_FILE_SIZE) {
+                $validator->errors()->add('document', 'The egg document may not be greater than 1000 kilobytes.');
+            }
+        });
+    }
+
+    /**
+     * Return the complete JSON document rather than only the fields used for validation.
+     */
+    public function document(): array
+    {
+        return $this->json()->all();
+    }
+
+    public function idempotencyKey(): string
+    {
+        return (string) $this->header('Idempotency-Key');
+    }
+
+    public function documentHash(): string
+    {
+        return hash('sha256', $this->getContent());
+    }
+}

--- a/app/Models/Egg.php
+++ b/app/Models/Egg.php
@@ -9,6 +9,8 @@ use Illuminate\Database\Eloquent\Relations\BelongsTo;
  * @property int $id
  * @property string $uuid
  * @property int $nest_id
+ * @property string|null $sync_key
+ * @property string|null $sync_hash
  * @property string $author
  * @property string $name
  * @property string|null $description
@@ -115,11 +117,13 @@ class Egg extends Model
 
     public static array $validationRules = [
         'nest_id' => 'required|bail|numeric|exists:nests,id',
+        'sync_key' => 'nullable|string|max:128',
+        'sync_hash' => 'nullable|string|size:64',
         'uuid' => 'required|string|size:36',
         'name' => 'required|string|max:191',
         'description' => 'string|nullable',
         'features' => 'array|nullable',
-        'author' => 'required|string|email',
+        'author' => 'required|string|email|max:191',
         'file_denylist' => 'array|nullable',
         'file_denylist.*' => 'string',
         'docker_images' => 'required|array|min:1',

--- a/app/Models/EggVariable.php
+++ b/app/Models/EggVariable.php
@@ -67,7 +67,7 @@ class EggVariable extends Model
         'default_value' => 'string',
         'user_viewable' => 'boolean',
         'user_editable' => 'boolean',
-        'rules' => 'required|string',
+        'rules' => 'required|string|max:191',
     ];
 
     protected $attributes = [

--- a/app/Services/Eggs/EggParserService.php
+++ b/app/Services/Eggs/EggParserService.php
@@ -4,12 +4,21 @@ namespace Pterodactyl\Services\Eggs;
 
 use Illuminate\Support\Arr;
 use Pterodactyl\Models\Egg;
+use Illuminate\Validation\Rule;
 use Illuminate\Http\UploadedFile;
 use Illuminate\Support\Collection;
+use Pterodactyl\Models\EggVariable;
+use Illuminate\Contracts\Validation\Factory as ValidationFactory;
 use Pterodactyl\Exceptions\Service\InvalidFileUploadException;
 
 class EggParserService
 {
+    public const MAX_FILE_SIZE = 1024 * 1000;
+
+    public function __construct(private ValidationFactory $validation)
+    {
+    }
+
     /**
      * Takes an uploaded file and parses out the egg configuration from within.
      *
@@ -22,28 +31,116 @@ class EggParserService
             throw new InvalidFileUploadException('The selected file is not valid and cannot be imported.');
         }
 
-        /** @var array $parsed */
-        $parsed = json_decode($file->openFile()->fread($file->getSize()), true, 512, JSON_THROW_ON_ERROR);
-        if (!in_array(Arr::get($parsed, 'meta.version') ?? '', ['PTDL_v1', 'PTDL_v2'])) {
-            throw new InvalidFileUploadException('The JSON file provided is not in a format that can be recognized.');
+        if ($file->getSize() > self::MAX_FILE_SIZE) {
+            throw new InvalidFileUploadException('The JSON file provided may not be greater than 1000 kilobytes.');
         }
 
-        return $this->convertToV2($parsed);
+        try {
+            $parsed = json_decode($file->openFile()->fread($file->getSize()), true, 512, JSON_THROW_ON_ERROR);
+        } catch (\JsonException $exception) {
+            throw new InvalidFileUploadException('The JSON file provided is not valid JSON.', $exception);
+        }
+
+        if (!is_array($parsed)) {
+            throw new InvalidFileUploadException('The JSON file provided must contain an egg document.');
+        }
+
+        return $this->parse($parsed);
+    }
+
+    /**
+     * Validates and normalizes a decoded egg document.
+     *
+     * @throws \Pterodactyl\Exceptions\Service\InvalidFileUploadException
+     */
+    public function parse(array $parsed): array
+    {
+        if (!in_array(Arr::get($parsed, 'meta.version') ?? '', ['PTDL_v1', 'PTDL_v2'])) {
+            throw new InvalidFileUploadException('The egg document is not in a format that can be recognized.');
+        }
+
+        $parsed = $this->convertToV2($parsed);
+        $validator = $this->validation->make($parsed, [
+            'meta' => ['required', 'array'],
+            'meta.version' => ['required', 'string', Rule::in(['PTDL_v1', 'PTDL_v2'])],
+            'meta.update_url' => ['sometimes', 'nullable', 'string'],
+            'name' => ['required', 'string', 'max:191'],
+            'author' => ['required', 'string', 'email', 'max:191'],
+            'description' => ['present', 'nullable', 'string'],
+            'features' => ['present', 'nullable', 'array'],
+            'features.*' => ['string'],
+            'docker_images' => [
+                'required',
+                'array',
+                'min:1',
+                function (string $attribute, mixed $value, \Closure $fail) {
+                    if (is_array($value) && array_values($value) === $value) {
+                        $fail('The docker images must be an object mapping labels to image names.');
+                    }
+                },
+            ],
+            'docker_images.*' => ['required', 'string'],
+            'file_denylist' => ['present', 'nullable', 'array'],
+            'file_denylist.*' => ['string'],
+            'startup' => [
+                'required',
+                'string',
+                function (string $attribute, mixed $value, \Closure $fail) {
+                    if (is_string($value) && trim($value) === '') {
+                        $fail('The startup command must not be blank.');
+                    }
+                },
+            ],
+            'config' => ['required', 'array'],
+            'config.files' => ['present', 'nullable', 'json'],
+            'config.startup' => ['present', 'nullable', 'json'],
+            'config.logs' => ['present', 'nullable', 'json'],
+            'config.stop' => ['present', 'nullable', 'string', 'max:191'],
+            'scripts' => ['required', 'array'],
+            'scripts.installation' => ['required', 'array'],
+            'scripts.installation.script' => ['present', 'nullable', 'string'],
+            'scripts.installation.container' => ['present', 'nullable', 'string', 'max:191'],
+            'scripts.installation.entrypoint' => ['present', 'nullable', 'string', 'max:191'],
+            'variables' => ['required', 'array'],
+            'variables.*' => ['array'],
+            'variables.*.name' => ['required', 'string', 'between:1,191'],
+            'variables.*.description' => ['present', 'string'],
+            'variables.*.env_variable' => [
+                'required',
+                'string',
+                'distinct',
+                'regex:/^[\w]{1,191}$/',
+                Rule::notIn(explode(',', EggVariable::RESERVED_ENV_NAMES)),
+            ],
+            'variables.*.default_value' => ['present', 'string'],
+            'variables.*.user_viewable' => ['required', 'boolean'],
+            'variables.*.user_editable' => ['required', 'boolean'],
+            'variables.*.rules' => ['required', 'string', 'max:191'],
+            'variables.*.field_type' => ['sometimes', 'string', Rule::in(['text'])],
+        ]);
+
+        if ($validator->fails()) {
+            throw new InvalidFileUploadException(sprintf(
+                'The egg document is invalid: %s',
+                $validator->errors()->first()
+            ));
+        }
+
+        return $parsed;
     }
 
     /**
      * Fills the provided model with the parsed JSON data.
      */
-    public function fillFromParsed(Egg $model, array $parsed): Egg
+    public function fillFromParsed(Egg $model, array $parsed, bool $importUpdateUrl = true): Egg
     {
-        return $model->forceFill([
+        $attributes = [
             'name' => Arr::get($parsed, 'name'),
             'description' => Arr::get($parsed, 'description'),
             'features' => Arr::get($parsed, 'features'),
             'docker_images' => Arr::get($parsed, 'docker_images'),
             'file_denylist' => Collection::make(Arr::get($parsed, 'file_denylist'))
                 ->filter(fn ($value) => !empty($value)),
-            'update_url' => Arr::get($parsed, 'meta.update_url'),
             'config_files' => Arr::get($parsed, 'config.files'),
             'config_startup' => Arr::get($parsed, 'config.startup'),
             'config_logs' => Arr::get($parsed, 'config.logs'),
@@ -52,7 +149,15 @@ class EggParserService
             'script_install' => Arr::get($parsed, 'scripts.installation.script'),
             'script_entry' => Arr::get($parsed, 'scripts.installation.entrypoint'),
             'script_container' => Arr::get($parsed, 'scripts.installation.container'),
-        ]);
+        ];
+
+        // API imports must not be able to inject a URL that the panel may later fetch.
+        // Multipart imports are trusted admin actions and retain their existing behavior.
+        if ($importUpdateUrl) {
+            $attributes['update_url'] = Arr::get($parsed, 'meta.update_url');
+        }
+
+        return $model->forceFill($attributes);
     }
 
     /**
@@ -76,14 +181,30 @@ class EggParserService
 
         unset($parsed['images'], $parsed['image']);
 
-        $parsed['docker_images'] = [];
-        foreach ($images as $image) {
-            $parsed['docker_images'][$image] = $image;
+        if (is_array($images)) {
+            $parsed['docker_images'] = [];
+            foreach ($images as $image) {
+                // V1 represented images as a list. Convert every valid value into
+                // the associative label => image shape required by PTDL v2.
+                if (!is_string($image)) {
+                    $parsed['docker_images'] = $images;
+
+                    break;
+                }
+
+                $parsed['docker_images'][$image] = $image;
+            }
+        } else {
+            // Leave malformed input in place so that schema validation can produce a
+            // controlled client error rather than PHP raising an error during conversion.
+            $parsed['docker_images'] = $images;
         }
 
-        $parsed['variables'] = array_map(function ($value) {
-            return array_merge($value, ['field_type' => 'text']);
-        }, $parsed['variables']);
+        if (isset($parsed['variables']) && is_array($parsed['variables'])) {
+            $parsed['variables'] = array_map(function ($value) {
+                return is_array($value) ? array_merge($value, ['field_type' => 'text']) : $value;
+            }, $parsed['variables']);
+        }
 
         return $parsed;
     }

--- a/app/Services/Eggs/EggParserService.php
+++ b/app/Services/Eggs/EggParserService.php
@@ -8,8 +8,8 @@ use Illuminate\Validation\Rule;
 use Illuminate\Http\UploadedFile;
 use Illuminate\Support\Collection;
 use Pterodactyl\Models\EggVariable;
-use Illuminate\Contracts\Validation\Factory as ValidationFactory;
 use Pterodactyl\Exceptions\Service\InvalidFileUploadException;
+use Illuminate\Contracts\Validation\Factory as ValidationFactory;
 
 class EggParserService
 {
@@ -120,10 +120,7 @@ class EggParserService
         ]);
 
         if ($validator->fails()) {
-            throw new InvalidFileUploadException(sprintf(
-                'The egg document is invalid: %s',
-                $validator->errors()->first()
-            ));
+            throw new InvalidFileUploadException(sprintf('The egg document is invalid: %s', $validator->errors()->first()));
         }
 
         return $parsed;

--- a/app/Services/Eggs/Sharing/EggImporterService.php
+++ b/app/Services/Eggs/Sharing/EggImporterService.php
@@ -8,11 +8,22 @@ use Pterodactyl\Models\Egg;
 use Pterodactyl\Models\Nest;
 use Illuminate\Http\UploadedFile;
 use Pterodactyl\Models\EggVariable;
+use Illuminate\Database\QueryException;
 use Illuminate\Database\ConnectionInterface;
 use Pterodactyl\Services\Eggs\EggParserService;
 
 class EggImporterService
 {
+    private const VARIABLE_ATTRIBUTES = [
+        'name',
+        'description',
+        'env_variable',
+        'default_value',
+        'user_viewable',
+        'user_editable',
+        'rules',
+    ];
+
     public function __construct(protected ConnectionInterface $connection, protected EggParserService $parser)
     {
     }
@@ -24,27 +35,127 @@ class EggImporterService
      */
     public function handle(UploadedFile $file, int $nest): Egg
     {
-        $parsed = $this->parser->handle($file);
+        return $this->import($this->parser->handle($file), $nest, true);
+    }
 
+    /**
+     * Import a new egg from an already-decoded JSON document.
+     *
+     * @throws \Pterodactyl\Exceptions\Service\InvalidFileUploadException|\Throwable
+     */
+    public function handleDocument(array $document, int $nest): Egg
+    {
+        return $this->import($this->parser->parse($document), $nest, false);
+    }
+
+    /**
+     * Import an API egg exactly once for a nest and idempotency key.
+     *
+     * @return array{egg: Egg, created: bool, conflict: bool}
+     *
+     * @throws \Pterodactyl\Exceptions\Service\InvalidFileUploadException|\Throwable
+     */
+    public function handleIdempotentDocument(
+        array $document,
+        int $nest,
+        string $syncKey,
+        string $syncHash
+    ): array {
+        $parsed = $this->parser->parse($document);
+        $nest = Nest::query()->findOrFail($nest);
+
+        try {
+            return $this->connection->transaction(function () use ($parsed, $nest, $syncKey, $syncHash) {
+                $existing = Egg::query()
+                    ->where('nest_id', $nest->id)
+                    ->where('sync_key', $syncKey)
+                    ->lockForUpdate()
+                    ->first();
+
+                if ($existing) {
+                    return $this->existingResult($existing, $syncHash);
+                }
+
+                $egg = $this->createEgg($parsed, $nest, false, $syncKey, $syncHash);
+
+                return ['egg' => $egg, 'created' => true, 'conflict' => false];
+            }, 3);
+        } catch (QueryException $exception) {
+            // Concurrent requests can both pass the initial lookup. The unique index is
+            // the final arbiter; inspect its winner after this transaction rolls back.
+            if (!$this->isUniqueConstraintViolation($exception)) {
+                throw $exception;
+            }
+
+            $existing = Egg::query()
+                ->where('nest_id', $nest->id)
+                ->where('sync_key', $syncKey)
+                ->first();
+
+            if (!$existing) {
+                throw $exception;
+            }
+
+            return $this->existingResult($existing, $syncHash);
+        }
+    }
+
+    private function import(array $parsed, int $nest, bool $importUpdateUrl): Egg
+    {
         /** @var \Pterodactyl\Models\Nest $nest */
         $nest = Nest::query()->with('eggs', 'eggs.variables')->findOrFail($nest);
 
-        return $this->connection->transaction(function () use ($nest, $parsed) {
-            $egg = (new Egg())->forceFill([
-                'uuid' => Uuid::uuid4()->toString(),
-                'nest_id' => $nest->id,
-                'author' => Arr::get($parsed, 'author'),
-                'copy_script_from' => null,
-            ]);
+        return $this->connection->transaction(
+            fn () => $this->createEgg($parsed, $nest, $importUpdateUrl)
+        );
+    }
 
-            $egg = $this->parser->fillFromParsed($egg, $parsed);
-            $egg->save();
+    private function createEgg(
+        array $parsed,
+        Nest $nest,
+        bool $importUpdateUrl,
+        ?string $syncKey = null,
+        ?string $syncHash = null
+    ): Egg {
+        $egg = (new Egg())->forceFill([
+            'uuid' => Uuid::uuid4()->toString(),
+            'nest_id' => $nest->id,
+            'author' => Arr::get($parsed, 'author'),
+            'copy_script_from' => null,
+            'sync_key' => $syncKey,
+            'sync_hash' => $syncHash,
+        ]);
 
-            foreach ($parsed['variables'] ?? [] as $variable) {
-                EggVariable::query()->forceCreate(array_merge($variable, ['egg_id' => $egg->id]));
-            }
+        $egg = $this->parser->fillFromParsed($egg, $parsed, $importUpdateUrl);
+        $egg->save();
 
-            return $egg;
-        });
+        foreach ($parsed['variables'] ?? [] as $variable) {
+            EggVariable::query()->forceCreate(array_merge(
+                Arr::only($variable, self::VARIABLE_ATTRIBUTES),
+                ['egg_id' => $egg->id]
+            ));
+        }
+
+        return $egg;
+    }
+
+    /** @return array{egg: Egg, created: bool, conflict: bool} */
+    private function existingResult(Egg $egg, string $syncHash): array
+    {
+        return [
+            'egg' => $egg,
+            'created' => false,
+            'conflict' => !hash_equals((string) $egg->sync_hash, $syncHash),
+        ];
+    }
+
+    private function isUniqueConstraintViolation(QueryException $exception): bool
+    {
+        $state = $exception->errorInfo[0] ?? null;
+        $driverCode = (int) ($exception->errorInfo[1] ?? 0);
+
+        return $state === '23505'
+            || $driverCode === 1062
+            || str_contains(strtolower($exception->getMessage()), 'unique constraint');
     }
 }

--- a/app/Services/Eggs/Sharing/EggUpdateImporterService.php
+++ b/app/Services/Eggs/Sharing/EggUpdateImporterService.php
@@ -2,8 +2,8 @@
 
 namespace Pterodactyl\Services\Eggs\Sharing;
 
-use Pterodactyl\Models\Egg;
 use Illuminate\Support\Arr;
+use Pterodactyl\Models\Egg;
 use Illuminate\Http\UploadedFile;
 use Pterodactyl\Models\EggVariable;
 use Illuminate\Database\ConnectionInterface;

--- a/app/Services/Eggs/Sharing/EggUpdateImporterService.php
+++ b/app/Services/Eggs/Sharing/EggUpdateImporterService.php
@@ -3,14 +3,24 @@
 namespace Pterodactyl\Services\Eggs\Sharing;
 
 use Pterodactyl\Models\Egg;
+use Illuminate\Support\Arr;
 use Illuminate\Http\UploadedFile;
-use Illuminate\Support\Collection;
 use Pterodactyl\Models\EggVariable;
 use Illuminate\Database\ConnectionInterface;
 use Pterodactyl\Services\Eggs\EggParserService;
 
 class EggUpdateImporterService
 {
+    private const VARIABLE_ATTRIBUTES = [
+        'name',
+        'description',
+        'env_variable',
+        'default_value',
+        'user_viewable',
+        'user_editable',
+        'rules',
+    ];
+
     /**
      * EggUpdateImporterService constructor.
      */
@@ -25,18 +35,36 @@ class EggUpdateImporterService
      */
     public function handle(Egg $egg, UploadedFile $file): Egg
     {
-        $parsed = $this->parser->handle($file);
+        return $this->update($egg, $this->parser->handle($file), true);
+    }
 
-        return $this->connection->transaction(function () use ($egg, $parsed) {
-            $egg = $this->parser->fillFromParsed($egg, $parsed);
+    /**
+     * Update an existing egg from an already-decoded JSON document.
+     *
+     * @throws \Pterodactyl\Exceptions\Service\InvalidFileUploadException|\Throwable
+     */
+    public function handleDocument(Egg $egg, array $document, ?string $syncHash = null): Egg
+    {
+        return $this->update($egg, $this->parser->parse($document), false, $syncHash);
+    }
+
+    private function update(Egg $egg, array $parsed, bool $importUpdateUrl, ?string $syncHash = null): Egg
+    {
+        return $this->connection->transaction(function () use ($egg, $parsed, $importUpdateUrl, $syncHash) {
+            $egg = Egg::query()->lockForUpdate()->findOrFail($egg->id);
+            $egg = $this->parser->fillFromParsed($egg, $parsed, $importUpdateUrl);
+            if (!is_null($egg->sync_key) && !is_null($syncHash)) {
+                $egg->sync_hash = $syncHash;
+            }
             $egg->save();
 
             // Update existing variables or create new ones.
             foreach ($parsed['variables'] ?? [] as $variable) {
                 EggVariable::unguarded(function () use ($egg, $variable) {
+                    $attributes = Arr::only($variable, self::VARIABLE_ATTRIBUTES);
                     $egg->variables()->updateOrCreate([
-                        'env_variable' => $variable['env_variable'],
-                    ], Collection::make($variable)->except('egg_id', 'env_variable')->toArray());
+                        'env_variable' => $attributes['env_variable'],
+                    ], Arr::except($attributes, 'env_variable'));
                 });
             }
 

--- a/app/Transformers/Api/Application/EggTransformer.php
+++ b/app/Transformers/Api/Application/EggTransformer.php
@@ -46,6 +46,20 @@ class EggTransformer extends BaseTransformer
             $files = new \stdClass();
         }
 
+        $dockerImages = $model->docker_images;
+        if (array_values($dockerImages) === $dockerImages) {
+            // Older panel data may contain the pre-v2 list shape. Keep reads
+            // compatible while always exposing the map expected by API SDKs.
+            $dockerImages = array_combine($dockerImages, $dockerImages) ?: [];
+        }
+
+        $startup = trim((string) $model->startup);
+        if ($startup === '') {
+            // Legacy/admin-created eggs may still have a nullable startup command.
+            // A shell no-op preserves those records without emitting nullable API data.
+            $startup = ':';
+        }
+
         return [
             'id' => $model->id,
             'uuid' => $model->uuid,
@@ -56,8 +70,8 @@ class EggTransformer extends BaseTransformer
             // "docker_image" is deprecated, but left here to avoid breaking too many things at once
             // in external software. We'll remove it down the road once things have gotten the chance
             // to upgrade to using "docker_images".
-            'docker_image' => count($model->docker_images) > 0 ? Arr::first($model->docker_images) : '',
-            'docker_images' => $model->docker_images,
+            'docker_image' => count($dockerImages) > 0 ? Arr::first($dockerImages) : '',
+            'docker_images' => empty($dockerImages) ? new \stdClass() : $dockerImages,
             'config' => [
                 'files' => $files,
                 'startup' => json_decode($model->config_startup, true),
@@ -66,7 +80,7 @@ class EggTransformer extends BaseTransformer
                 'file_denylist' => $model->file_denylist,
                 'extends' => $model->config_from,
             ],
-            'startup' => $model->startup,
+            'startup' => $startup,
             'script' => [
                 'privileged' => $model->script_is_privileged,
                 'install' => $model->script_install,

--- a/database/migrations/2026_07_30_000000_add_sync_identity_to_eggs_table.php
+++ b/database/migrations/2026_07_30_000000_add_sync_identity_to_eggs_table.php
@@ -1,0 +1,25 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class AddSyncIdentityToEggsTable extends Migration
+{
+    public function up()
+    {
+        Schema::table('eggs', function (Blueprint $table) {
+            $table->string('sync_key', 128)->nullable()->after('nest_id');
+            $table->char('sync_hash', 64)->nullable()->after('sync_key');
+            $table->unique(['nest_id', 'sync_key'], 'eggs_nest_id_sync_key_unique');
+        });
+    }
+
+    public function down()
+    {
+        Schema::table('eggs', function (Blueprint $table) {
+            $table->dropUnique('eggs_nest_id_sync_key_unique');
+            $table->dropColumn(['sync_key', 'sync_hash']);
+        });
+    }
+}

--- a/routes/api-application.php
+++ b/routes/api-application.php
@@ -119,6 +119,8 @@ Route::group(['prefix' => '/nests'], function () {
     // Egg Management Endpoint
     Route::group(['prefix' => '/{nest:id}/eggs'], function () {
         Route::get('/', [Application\Nests\EggController::class, 'index'])->name('api.application.nests.eggs');
+        Route::post('/', [Application\Nests\EggController::class, 'store'])->name('api.application.nests.eggs.store');
         Route::get('/{egg:id}', [Application\Nests\EggController::class, 'view'])->name('api.application.nests.eggs.view');
+        Route::put('/{egg:id}', [Application\Nests\EggController::class, 'update'])->name('api.application.nests.eggs.update');
     });
 });


### PR DESCRIPTION
## Summary
- add authenticated Application API endpoints to import and update egg JSON
- make imports retry-safe with a durable per-nest idempotency key
- validate and normalize PTDL documents before transactional persistence
- prevent API-provided update URLs and unexpected variable attributes from crossing the trust boundary
- move CI to supported Ubuntu runners and prevent registry pushes from pull requests

## API contract
- `POST /api/application/nests/{nest}/eggs` with `Idempotency-Key`
  - `201` for a new import
  - `200` for a same-key, same-payload retry
  - `409 EggSyncConflict` for a same-key, different-payload request
- `PUT /api/application/nests/{nest}/eggs/{egg}` updates an existing egg

Both endpoints require Application API `eggs.write` permission.

## Deployment
Run `php artisan migrate --force` to add the nullable egg sync identity columns and per-nest unique index.

## Verification
- Lint: passed
- UI build: passed
- PHP 8.0/8.1 tests on MariaDB/MySQL: passed
- `git diff --check`
- static cross-repository contract and security review

The Docker publish job is intentionally skipped for pull requests.